### PR TITLE
Add a default browser Open() for UNIX systems

### DIFF
--- a/internal/browser/browser_unix.go
+++ b/internal/browser/browser_unix.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"os/exec"
+)
+
+// open the browser
+func Open(url string) (err error) {
+	return exec.Command("xdg-open", url).Start()
+}

--- a/internal/browser/browser_unix.go
+++ b/internal/browser/browser_unix.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package browser
 

--- a/internal/browser/browser_unix.go
+++ b/internal/browser/browser_unix.go
@@ -1,3 +1,5 @@
+//go:build !darwin && !linux
+
 package browser
 
 import (


### PR DESCRIPTION
For UNIX-like systems other than Linux, add a browser Open() call.  Keep Linux as-is to continue handling WSL environments.