### PR TITLE
Correctly convert .md links with tags to .html

### DIFF
--- a/test.md
+++ b/test.md
@@ -140,6 +140,8 @@ Right aligned columns
 
 [Link to .md](test.md)
 
+[Link to tag of .md](test.md#links)
+
 [link with title](http://nodeca.github.io/pica/demo/ "title text!")
 
 Autoconverted link https://github.com/nodeca/pica (enable linkify to see)


### PR DESCRIPTION
Before, if the link contained a tag, gm would not try to convert it.
This commit slightly modifies the previous behaviour so that if the link is a filename that contains a #tag, the tag would be added to the end of the converted filename as well.